### PR TITLE
Bump @phillipsharring/graspr-build to ^0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "devDependencies": {
-                "@phillipsharring/graspr-build": "^0.1.0",
+                "@phillipsharring/graspr-build": "^0.2.1",
                 "@tailwindcss/vite": "^4.1.18",
                 "tailwindcss": "^4.1.18",
                 "vite": "^7.3.0"
@@ -508,9 +508,9 @@
             }
         },
         "node_modules/@phillipsharring/graspr-build": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@phillipsharring/graspr-build/-/graspr-build-0.1.0.tgz",
-            "integrity": "sha512-JvbugcNXdldRltYIgVNDdFZbBnr3n+ID5QT0eKzeiQRxEpz0C95T4iQF/sWsce40zXB3LBXaC0v+cmuLfJ9HoA==",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@phillipsharring/graspr-build/-/graspr-build-0.2.1.tgz",
+            "integrity": "sha512-mzwv3xV0J0J1lfFDKBwYIwaT7KqWp9H+ZEGdpfQsJhiZoBacYmECehBWZvXFalzTJCN4ZStQtlxxyOnfD31hdg==",
             "dev": true,
             "license": "MIT",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "author": "Phillip Harrington <phillip@phillipharrington.com> (https://phillipharrington.com/)",
     "license": "MIT",
     "devDependencies": {
-        "@phillipsharring/graspr-build": "^0.1.0",
+        "@phillipsharring/graspr-build": "^0.2.1",
         "@tailwindcss/vite": "^4.1.18",
         "tailwindcss": "^4.1.18",
         "vite": "^7.3.0"


### PR DESCRIPTION
## Summary
- Bumps `@phillipsharring/graspr-build` from `^0.1.0` to `^0.2.1` to pick up a phantom-whitespace fix in the HTML compiler.
- Inline component templates were bleeding their trailing newline into the page, rendering `<lnk>here</lnk>,` as `here ,` instead of `here,`. The fix in graspr-build 0.2.1 trims template files at read time.
- Affects every inline component (`<lnk>`, `<cde>`, etc.) across all 16 pages.

## Test plan
- [x] `npm install` pulls 0.2.1
- [x] `npm run build` succeeds, all 16 pages baked
- [x] `dist/colophon/index.html` renders `<a ...>here</a>,` (no space)
- [x] `grep -r '</a>\s\+,' dist/` returns no matches
- [x] `grep -r '</code>\s\+[,.]' dist/` returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)