### PR TITLE
Mobile polish, copy refresh, and outdated content sweep

### DIFF
--- a/content/components/layout-header.html
+++ b/content/components/layout-header.html
@@ -3,7 +3,10 @@
 >
     <div class="mx-auto flex h-16 max-w-5xl flex-row items-center px-4 sm:px-6 md:px-8 lg:px-16">
         <div class="z-20">
-            <a href="/" class="text-th-heading hover:text-th-accent transition-colors duration-200">
+            <a
+                href="/"
+                class="text-th-accent sm:text-th-heading sm:hover:text-th-accent transition-colors duration-200"
+            >
                 <initials></initials>
             </a>
         </div>

--- a/content/pages/about.html
+++ b/content/pages/about.html
@@ -6,7 +6,7 @@
     />
     <meta
         name="keywords"
-        content="Phillip Harrington, web development, PHP 8, Laravel 11, multi-tenant SaaS, music projects, drummer, Thirsty Curses, Scratch Track, blog, musings, social media @phillipsharring, Smithfield NC, life journey, career history, original music, cover bands"
+        content="Phillip Harrington, web development, PHP 8, Laravel 11, multi-tenant SaaS, music projects, drummer, Forest Rising, Thirsty Curses, Scratch Track, blog, musings, social media @phillipsharring, Smithfield NC, life journey, career history, original music, cover bands"
     />
 </page-head>
 <article>

--- a/content/pages/colophon.html
+++ b/content/pages/colophon.html
@@ -41,8 +41,9 @@
         </p>
         <p>
             The code is
-            <lnk to="https://github.com/phillipsharring/phillipharrington.com">here</lnk>, if you're
-            curious.
+            <lnk to="https://github.com/phillipsharring/phillipharrington.com">here</lnk>, and
+            <cde>graspr-build</cde> is
+            <lnk to="https://github.com/phillipsharring/graspr-build">here</lnk>, if you're curious.
         </p>
         <heading h3 id="abstract-urls">Abstract URLs</heading>
         <p>

--- a/content/pages/contact.html
+++ b/content/pages/contact.html
@@ -11,7 +11,7 @@
 </page-head>
 <article>
     <spaced>
-        <heading h1 id="blog">Contact</heading>
+        <heading h1 id="contact">Contact</heading>
         <p>
             I can be reached on
             <lnk to="https://www.linkedin.com/in/phillipsharring" blank>LinkedIn</lnk>

--- a/content/pages/index.html
+++ b/content/pages/index.html
@@ -2,11 +2,11 @@
 <page-head>
     <meta
         name="description"
-        content="Phillip Harrington: Lead Software Engineer, musician, and tech modernizer with 25+ years of experience. Currently improving EdTech at Abre.io while drumming and contributing to music projects like Thirsty Curses. Explore his blog, work history, and expertise in Laravel, Vue.js, PHP, and more."
+        content="Phillip Harrington: Lead Software Engineer, musician, and tech modernizer with 25+ years of experience. Currently improving EdTech at Abre, Inc. and drumming with Forest Rising. Explore his blog, work history, and expertise in Laravel, Vue.js, PHP, and more."
     />
     <meta
         name="keywords"
-        content="Phillip Harrington, Lead Software Engineer, musician, EdTech, Abre.io, Laravel, Vue.js, Nuxt, PHP, JavaScript, tech modernizer, 25+ years development experience, Thirsty Curses, Spectre Records, Signals from Satellites, blog, selected work history, code modernization, professional testimonials, web technologies, tech and music expertise"
+        content="Phillip Harrington, Lead Software Engineer, musician, EdTech, Abre, Laravel, Vue.js, Nuxt, PHP, JavaScript, tech modernizer, 25+ years development experience, Forest Rising, Thirsty Curses, Spectre Records, Signals from Satellites, blog, selected work history, code modernization, professional testimonials, web technologies, tech and music expertise"
     />
 </page-head>
 <article>
@@ -141,7 +141,9 @@
         >
             Appears On
         </h3>
-        <div class="flex flex-row flex-wrap justify-center gap-4 sm:gap-6">
+        <div
+            class="mx-auto flex max-w-xs flex-row flex-wrap justify-center gap-4 sm:max-w-none sm:gap-6"
+        >
             <img
                 src="/img/thirsty-curses-self-titled.jpg"
                 class="album-art h-20 sm:h-32"

--- a/content/pages/music.html
+++ b/content/pages/music.html
@@ -2,11 +2,11 @@
 <page-head>
     <meta
         name="description"
-        content="Dive into the musical journey of Phillip Harrington, a lifelong drummer with a passion for rock music. Explore his performances with bands like Thirsty Curses, music education at Berklee, and his drum setup."
+        content="Dive into the musical journey of Phillip Harrington, a lifelong drummer with a passion for rock music. Currently playing with Forest Rising. Explore past projects like Thirsty Curses, music education at Berklee, and his drum setup."
     />
     <meta
         name="keywords"
-        content="Phillip Harrington, drummer, rock music, Berklee College of Music, music education, drumming equipment, TAMA drums, Vic Firth sticks, alternative rock, Americana, music projects, live performance, Raleigh NC, original music, cover bands, Bandcamp releases, Signals From Satellites, garage rock"
+        content="Phillip Harrington, drummer, rock music, Berklee College of Music, music education, drumming equipment, TAMA drums, Vic Firth sticks, alternative rock, Americana, music projects, live performance, Raleigh NC, original music, cover bands, Forest Rising, Thirsty Curses, Signals From Satellites, garage rock"
     />
 </page-head>
 <article>
@@ -37,18 +37,14 @@
         <quote citation="Jeff Porcaro">
             <p>“The best thing for drummers is to have fun.”</p>
         </quote>
-        <heading h3>Current Band</heading>
-        <p>
-            I've joined
-            <lnk to="https://forestrising.com/" blank>Forest Rising</lnk>, playing covers and
-            original music. We're booked through the rest of the year!
-        </p>
         <heading h2 id="highlights">Highlights</heading>
         <band>
-            <heading h3 id="power-child">Power Child</heading>
+            <heading h3 id="forest-rising">Forest Rising</heading>
             <p>
-                Drums, 2022-2023 - A 90s alt-rock cover band based in Raleigh, NC playing music from
-                bands like Audioslave, Soundgarden, Pearl Jam, Rage Against the Machine, and more!
+                Drums, 2026-present -
+                <lnk to="https://forestrising.com/" blank>Forest Rising</lnk>, playing covers and
+                original music. We're booked through the rest of the year — check the website for
+                upcoming shows!
             </p>
         </band>
         <band>

--- a/content/pages/now.html
+++ b/content/pages/now.html
@@ -2,7 +2,7 @@
 <page-head>
     <meta
         name="description"
-        content="Discover what's happening now in Phillip Harrington's life: balancing a full house with family, making music with my friend's band, and reflecting on past musical projects. Updated June 2025."
+        content="What's happening now in Phillip Harrington's life: a full house with family, drumming with Forest Rising, and a great run at the day job."
     />
     <meta
         name="keywords"
@@ -11,7 +11,7 @@
 </page-head>
 <article>
     <heading h1 id="now">Now</heading>
-    <byline date="June 2025" updated location="Smithfield, NC">
+    <byline date="Apr 2026" updated location="Smithfield, NC">
         This is a
         <lnk to="https://nownownow.com/about" blank>Now page</lnk>
     </byline>


### PR DESCRIPTION
- Mobile: logo always green (no hover state on touch); narrow album cover container so 5 covers wrap as 3+2 instead of 4+1
- Colophon: link graspr-build alongside the site source
- Music: drop Power Child block, replace first highlight with Forest Rising (and remove the now-redundant "Current Band" section)
- Sweep meta descriptions/keywords across index, about, music, now to reference Forest Rising as the current band rather than Thirsty Curses
- Now: update byline to Apr 2026 and refresh meta description
- Contact: fix duplicate id="blog" copy-paste on the Contact heading